### PR TITLE
fix: misspelled include guard macro COSTANTS_H

### DIFF
--- a/common/include/constants.hpp
+++ b/common/include/constants.hpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef COSTANTS_H
-#define COSTANTS_H
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
### Problem
fix: misspelled include guard macro COSTANTS_H

### Fix
Replace:
```
#ifndef COSTANTS_H
#define COSTANTS_H
```

with:
```
#ifndef CONSTANTS_H
#define CONSTANTS_H
```

### Files changed
- `common/include/constants.hpp`