### PR TITLE
fix: define PUSH_RANGE_STR no-op when NVTX is disabled

### DIFF
--- a/receiver/include/cuda_headers.hpp
+++ b/receiver/include/cuda_headers.hpp
@@ -65,6 +65,7 @@
   #define POP_RANGE do { nvtxRangePop(); } while(0)
 #else
   #define PUSH_RANGE(name,cid)
+  #define PUSH_RANGE_STR(cid, FMT, ARGS...) do { } while(0)
   #define POP_RANGE
 #endif
 


### PR DESCRIPTION
### Problem
fix: define PUSH_RANGE_STR no-op when NVTX is disabled

### Fix
Replace:
```
#else
  #define PUSH_RANGE(name,cid)
  #define POP_RANGE
#endif
```

with:
```
#else
  #define PUSH_RANGE(name,cid)
  #define PUSH_RANGE_STR(cid, FMT, ARGS...) do { } while(0)
  #define POP_RANGE
#endif
```

### Files changed
- `receiver/include/cuda_headers.hpp`