### PR TITLE
fix(ru-recv): flow rule pointer array frule not initialized (+1 more)

### DIFF
--- a/receiver/src/ru_recv.cpp
+++ b/receiver/src/ru_recv.cpp
@@ -126,6 +126,7 @@ RURecv::RURecv(int _index, struct rte_ether_addr &_eth_addr, uint16_t _ap0,
 {
 	good_pkts = 0;
 	bad_pkts = 0;
+	memset(frule, 0, sizeof(frule));
 
 	CUDA_CHECK(cudaMallocHost((void **)&burst_list, MAX_BURSTS_X_PIPELINE * sizeof(struct burst_item)));
 
@@ -155,5 +156,7 @@ RURecv::~RURecv() {
 void RURecv::setFlowRule() {
 	for (int iqueue = 0; iqueue < NUM_AP; iqueue++) {
 		frule[iqueue] = setup_rules(port_id, vlan_tci, rxq_list[iqueue], eth_addr, ECPRI_MSG_TYPE_IQ, eAxC_list[iqueue]);
+		if (frule[iqueue] == NULL)
+			rte_panic("Failed to create flow rule for queue %d\n", iqueue);
 	}
 }


### PR DESCRIPTION
This PR addresses 2 issues in `receiver/src/ru_recv.cpp`.

#### Fix 1
fix: flow rule pointer array frule not initialized

**Fix:** Replace:
```
RURecv::RURecv(int _index, struct rte_ether_addr &_eth_addr, uint16_t _ap0,
			uint16_t _ap1, uint16_t _ap2, uint16_t _ap3, uint16_t _vlan_tci,
			uint8_t _port_id, uint16_t _rxd, uint16_t _txd,
			struct rte_mempool *_mpool)
			:
			RU(_index, _eth_addr, _ap0, _ap1, _ap2, _ap3, _vlan_tci, _port_id, _rxd, _txd, _mpool)
{
	good_pkts = 0;
	bad_pkts = 0;
```

with:
```
RURecv::RURecv(int _index, struct rte_ether_addr &_eth_addr, uint16_t _ap0,
			uint16_t _ap1, uint16_t _ap2, uint16_t _ap3, uint16_t _vlan_tci,
			uint8_t _port_id, uint16_t _rxd, uint16_t _txd,
			struct rte_mempool *_mpool)
			:
			RU(_index, _eth_addr, _ap0, _ap1, _ap2, _ap3, _vlan_tci, _port_id, _rxd, _txd, _mpool)
{
	good_pkts = 0;
	bad_pkts = 0;
	memset(frule, 0, sizeof(frule));
```

#### Fix 2
fix: setFlowRule ignores rte_flow_create failure

**Fix:** Replace:
```
void RURecv::setFlowRule() {
	for (int iqueue = 0; iqueue < NUM_AP; iqueue++) {
		frule[iqueue] = setup_rules(port_id, vlan_tci, rxq_list[iqueue], eth_addr, ECPRI_MSG_TYPE_IQ, eAxC_list[iqueue]);
	}
}
```

with:
```
void RURecv::setFlowRule() {
	for (int iqueue = 0; iqueue < NUM_AP; iqueue++) {
		frule[iqueue] = setup_rules(port_id, vlan_tci, rxq_list[iqueue], eth_addr, ECPRI_MSG_TYPE_IQ, eAxC_list[iqueue]);
		if (frule[iqueue] == NULL)
			rte_panic("Failed to create flow rule for queue %d\n", iqueue);
	}
}
```

### Files changed
- `receiver/src/ru_recv.cpp`