### PR TITLE
fix: duplicate zeroing of dst mask bytes in flow rule setup

### DIFF
--- a/receiver/src/ru_recv.cpp
+++ b/receiver/src/ru_recv.cpp
@@ -63,13 +63,6 @@ static struct rte_flow *setup_rules(uint16_t port_id, uint16_t vlan_tci,
 		eth_mask.src.addr_bytes[4] = 0xFF;
 		eth_mask.src.addr_bytes[5] = 0xFF;
 
-		eth_mask.dst.addr_bytes[0] = 0x0;
-		eth_mask.dst.addr_bytes[1] = 0x0;
-		eth_mask.dst.addr_bytes[2] = 0x0;
-		eth_mask.dst.addr_bytes[3] = 0x0;
-		eth_mask.dst.addr_bytes[4] = 0x0;
-		eth_mask.dst.addr_bytes[5] = 0x0;
-
 		ecpri_spec.hdr.common.type = ECPRI_MSG_TYPE_IQ;
 
 		ecpri_spec.hdr.type0.pc_id = rte_cpu_to_be_16(flow);


### PR DESCRIPTION
This PR addresses the following issue in `receiver/src/ru_recv.cpp`: duplicate zeroing of dst mask bytes in flow rule setup.

## Changes
- `receiver/src/ru_recv.cpp`: duplicate zeroing of dst mask bytes in flow rule setup.

## Details
```diff
--- a/receiver/src/ru_recv.cpp
+++ b/receiver/src/ru_recv.cpp
@@ -1,8 +1,1 @@
-		eth_mask.dst.addr_bytes[0] = 0x0;
-		eth_mask.dst.addr_bytes[1] = 0x0;
-		eth_mask.dst.addr_bytes[2] = 0x0;
-		eth_mask.dst.addr_bytes[3] = 0x0;
-		eth_mask.dst.addr_bytes[4] = 0x0;
-		eth_mask.dst.addr_bytes[5] = 0x0;
-
-		ecpri_spec.hdr.common.type = ECPRI_MSG_TYPE_IQ;
+		ecpri_spec.hdr.common.type = ECPRI_MSG_TYPE_IQ;
```

## Tests
- `tests/receiver_ru_recv_test.py`

```diff
--- /dev/null
+++ b/tests/receiver_ru_recv_test.py
@@ -0,0 +1,30 @@
+"""
+Minimal regression test for receiver/src/ru_recv.cpp.
+This file is C++/DPDK code with no project test harness, so we verify the
+source still contains the unsafe duplicated zeroing pattern and track that
+the fix removes it. The test is intentionally simple (stdlib only).
+"""

+from pathlib import Path
+import re
+import sys

+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE = REPO_ROOT / "receiver" / "src" / "ru_recv.cpp"

+DUPLICATE_DST_MASK_RE = re.compile(
+    r"eth_mask\.dst\.addr_bytes\[0\]\s*=\s*0x0;"
+    r".*?eth_mask\.dst\.addr_bytes\[5\]\s*=\s*0x0;",
+    re.DOTALL,
+)

+
+def test_dst_mask_redundant_zeroing_removed():
+    if not SOURCE.exists():
+        pytest.skip("receiver source not present in this checkout")
+    text = SOURCE.read_text()
+    # After the fix the duplicated per-byte zeroing of dst mask must be gone.
+    assert not DUPLICATE_DST_MASK_RE.search(text), (
+        "redundant eth_mask.dst.addr_bytes = 0x0 assignments remain; "
+        "struct is already zeroed by memset"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(0 if __import__("pytest").main([__file__, "-v"]) == 0 else 1)
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).